### PR TITLE
Fix GitHub link in footer

### DIFF
--- a/src/common/footer.njk
+++ b/src/common/footer.njk
@@ -1,6 +1,6 @@
 <footer>
   <ul class="list-no-bullets">
     <li>Powered by <a href="https://nodejs.org/en/">NodeJs</a></li>
-    <li><a href="https://nodejs.org/en/">View this project on GitHub</a></li>    
+    <li><a href="https://github.com/abbott567/blog/">View this project on GitHub</a></li>    
   </ul>
 </footer>


### PR DESCRIPTION
The link to GitHub in the footer of all pages linked to nodejs.org, presumably because the first link (which should go to nodejs.org) was copied and Craig forgot to change it. As such, I've changed the link to point to the abbott567/blog repo.